### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![FastMCP](https://img.shields.io/badge/FastMCP-Latest-green.svg)](https://github.com/jlowin/fastmcp)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+<a href="https://glama.ai/mcp/servers/@caiovicentino/debank-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@caiovicentino/debank-mcp-server/badge" alt="DeBank Server MCP server" />
+</a>
+
 ## 📋 Sobre
 
 O **DeBank MCP Server** é um servidor MCP que conecta a poderosa API do DeBank com assistentes de IA como o Claude Desktop. Com ele, você pode consultar dados DeFi de forma natural através de conversação, incluindo:


### PR DESCRIPTION
This PR adds a badge for the [DeBank MCP Server](https://glama.ai/mcp/servers/@caiovicentino/debank-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@caiovicentino/debank-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@caiovicentino/debank-mcp-server/badge" alt="DeBank Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.